### PR TITLE
Avoid nil completion.

### DIFF
--- a/DTLocationManager/DTBaseLocationManager.m
+++ b/DTLocationManager/DTBaseLocationManager.m
@@ -145,11 +145,17 @@
         case kCLAuthorizationStatusNotDetermined:break;
             
         case kCLAuthorizationStatusRestricted:
-            self.completion(nil,LocationResultTypeFailure);
+            if (self.completion)
+            {
+                self.completion(nil,LocationResultTypeFailure);
+            }
             [self stop];
             break;
         case kCLAuthorizationStatusDenied:
-            self.completion(nil,LocationResultTypeFailure);
+            if (self.completion)
+            {
+                self.completion(nil,LocationResultTypeFailure);
+            }
             [self stop];
             break;
             


### PR DESCRIPTION
Avoid crash when we receive Denied authorization status and completion block is nil.
